### PR TITLE
Fix: Error Message Not Appeared When Validating Payment Gateway Settings

### DIFF
--- a/app/Modules/PaymentMethods/Core/AbstractPaymentGateway.php
+++ b/app/Modules/PaymentMethods/Core/AbstractPaymentGateway.php
@@ -129,7 +129,7 @@ abstract class AbstractPaymentGateway implements PaymentGatewayInterface
         // validate if the settings/credentials are correct
         if ('yes' === $is_active) {
             $response = static::validateSettings($settings);
-            if (isset($reponse['status']) && $response['status'] === 'failed') {
+            if (isset($response['status']) && $response['status'] === 'failed') {
                 wp_send_json(
                     [
                         'status'  => 'failed',


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Fix typo which caused error message not appeared during payment gateway settings validation.