### PR TITLE
Fix typo in response variable name in updateSettings() 

### DIFF
--- a/app/Modules/PaymentMethods/Core/AbstractPaymentGateway.php
+++ b/app/Modules/PaymentMethods/Core/AbstractPaymentGateway.php
@@ -129,7 +129,7 @@ abstract class AbstractPaymentGateway implements PaymentGatewayInterface
         // validate if the settings/credentials are correct
         if ('yes' === $is_active) {
             $response = static::validateSettings($settings);
-            if (isset($reponse['status']) && $response['status'] === 'failed') {
+            if (isset($response['status']) && $response['status'] === 'failed') {
                 wp_send_json(
                     [
                         'status'  => 'failed',


### PR DESCRIPTION
**Summary**
--
This typo in `updateSettings()` makes function `validateSettings()` cant be called, even when given variable status "failed" when validating, and the setting will always be saved successfully.