### PR TITLE
Do not record local refunds before remote gateway success

### DIFF
--- a/app/Services/Payments/Refund.php
+++ b/app/Services/Payments/Refund.php
@@ -57,11 +57,6 @@ class Refund
             'uuid'                => md5(time() . wp_generate_uuid4())
         ];
 
-        $refundTransaction = OrderTransaction::query()->create($orderTransactions);
-
-        // update the main parent transaction meta
-        PaymentHelper::updateTransactionRefundedTotal($transaction, $refundAmount);
-
         $manualRefund = apply_filters('fluent_cart/order_refund_manually', [
             'status' => 'no',
             'source' => ''
@@ -80,17 +75,32 @@ class Refund
 
 
         if (Arr::get($manualRefund, 'status') !== 'yes') {
-            if ($gateway = App::gateway($transaction->payment_method)) {
-                if ($gateway->has('refund')) {
-                    $vendorRefundId = $gateway->processRefund($transaction, $refundAmount, $args);
-                }
+            $gateway = App::gateway($transaction->payment_method);
+
+            if (!$gateway || !$gateway->has('refund')) {
+                return new \WP_Error(
+                    'refund_not_supported',
+                    __('Refund process is not implemented for this payment gateway.', 'fluent-cart')
+                );
             }
 
-            if (!is_wp_error($vendorRefundId) && $vendorRefundId) {
-                $refundTransaction->vendor_charge_id = $vendorRefundId;
-                $refundTransaction->save();
+            $vendorRefundId = $gateway->processRefund($transaction, $refundAmount, $args);
+
+            if (is_wp_error($vendorRefundId)) {
+                return $vendorRefundId;
             }
         }
+
+        $refundTransaction = OrderTransaction::query()->create($orderTransactions);
+
+        if ($vendorRefundId) {
+            $refundTransaction->vendor_charge_id = $vendorRefundId;
+            $refundTransaction->save();
+        }
+
+        // Update refunded totals only after the remote refund succeeded
+        // or the flow was explicitly marked as manual.
+        PaymentHelper::updateTransactionRefundedTotal($transaction, $refundAmount);
 
         $manageStock = filter_var(Arr::get($args, 'manageStock'), FILTER_VALIDATE_BOOLEAN);
 
@@ -99,7 +109,7 @@ class Refund
         return [
             'refund_transaction' => $refundTransaction,
             'vendor_refund_id'   => $vendorRefundId,
-            'manual_refund'  => $manualRefund
+            'manual_refund'      => $manualRefund
         ];
     }
 


### PR DESCRIPTION
## Summary

Fresh submission against current `master` (`1.3.25`) as requested after the mirror-cleanup issue closed the previous PR.

This fixes the refund flow so FluentCart does not create a local refund record, bump refunded totals, or dispatch `OrderRefund` before the gateway refund has actually succeeded.

## What changed

- run the remote gateway refund first for non-manual refunds
- return the gateway `WP_Error` immediately
- return `refund_not_supported` when the gateway cannot actually refund
- create the local refund transaction only after remote success
- update refunded totals only after remote success or an explicit manual refund
- keep manual refunds working as before

## Verification

- `php -l app/Services/Payments/Refund.php`

Supersedes #43.