### PR TITLE
Add filter hook for order data at checkout

### DIFF
--- a/app/Helpers/AdminOrderProcessor.php
+++ b/app/Helpers/AdminOrderProcessor.php
@@ -248,6 +248,27 @@ class AdminOrderProcessor
 
         $totalAmount = $orderData['subtotal'] - $orderData['coupon_discount_total'] - $orderData['manual_discount_total'] + $orderData['shipping_total'] + $orderData['tax_total'];
         $orderData['total_amount'] = $totalAmount > 0 ? $totalAmount : 0;
+
+        /**
+         * Filter the prepared order data before it is used for order creation.
+         *
+         * This mirrors the frontend checkout hook so integrations can adjust
+         * order payload fields consistently for manual admin orders too.
+         *
+         * @param array $orderData Prepared order data array.
+         * @param array $context {
+         *     Additional context for the filter.
+         *
+         *     @type array $items Formatted order items with prices and quantities.
+         *     @type array $args  Admin order arguments: customer data, payment
+         *                        method, shipping, tax, notes, and IP data.
+         * }
+         */
+        $orderData = apply_filters('fluent_cart/checkout/order_data', $orderData, [
+            'items' => $this->formattedIOrderItems,
+            'args'  => $this->args,
+        ]);
+
         $this->orderData = $orderData;
     }
 

--- a/app/Helpers/CheckoutProcessor.php
+++ b/app/Helpers/CheckoutProcessor.php
@@ -890,6 +890,28 @@ class CheckoutProcessor
         $totalAmount = $orderData['subtotal'] - $orderData['coupon_discount_total'] - $orderData['manual_discount_total'] + $orderData['fee_total'] + $orderData['shipping_total'] + $estimatedTaxTotal + $estimatedShippingTax;
 
         $orderData['total_amount'] = $totalAmount > 0 ? $totalAmount : 0;
+
+        /**
+         * Filter the prepared order data before it is used for order creation.
+         *
+         * This runs after FluentCart calculates totals, so plugins can adjust
+         * currency, rate, totals, config, mode, or any other order field before
+         * the order model, transaction, and subscription are derived from it.
+         *
+         * @param array $orderData Prepared order data array.
+         * @param array $context {
+         *     Additional context for the filter.
+         *
+         *     @type array $items Formatted order items with prices and quantities.
+         *     @type array $args  Checkout arguments: customer data, payment method,
+         *                        shipping, tax, coupons, fees, and IP data.
+         * }
+         */
+        $orderData = apply_filters('fluent_cart/checkout/order_data', $orderData, [
+            'items' => $this->formattedIOrderItems,
+            'args'  => $this->args,
+        ]);
+
         $this->orderData = $orderData;
     }
 


### PR DESCRIPTION
## Summary

Fresh submission against current `master` (`1.3.25`) after the mirror-cleanup issue closed the earlier PR history.

This adds a single `fluent_cart/checkout/order_data` filter in `prepareOrderData()` for both `CheckoutProcessor` and `AdminOrderProcessor`, after totals are computed and before the order model is created.

## Why

This gives integrations one place to adjust any order field before creation: currency, rate, totals, config, mode, fees, shipping, tax, notes, or other order payload fields. The filtered values then propagate naturally into the order transaction and subscription data derived from the prepared order payload.

## What changed

- add the filter to frontend checkout order preparation
- add the same filter to admin manual-order preparation
- pass a small context payload with `items` and `args`

## Verification

- `php -l app/Helpers/CheckoutProcessor.php`
- `php -l app/Helpers/AdminOrderProcessor.php`

Supersedes #36.