### PR TITLE
fix: wrap missing translatable strings in payment gateway meta

### DIFF
--- a/app/Modules/PaymentMethods/PromoGateways/Addons/FlutterwaveAddon.php
+++ b/app/Modules/PaymentMethods/PromoGateways/Addons/FlutterwaveAddon.php
@@ -41,7 +41,7 @@ class FlutterwaveAddon extends AbstractPaymentGateway
             'title' => 'Flutterwave',
             'route' => 'flutterwave',
             'slug' => 'flutterwave',
-            'description' => 'Pay securely with Flutterwave - Card, Bank Transfer, Mobile Money, and more',
+            'description' => __('Pay securely with Flutterwave - Card, Bank Transfer, Mobile Money, and more', 'fluent-cart'),
             'logo' => Vite::getAssetUrl("images/payment-methods/flutterwave-logo.svg"),
             'icon' => Vite::getAssetUrl("images/payment-methods/flutterwave-logo.svg"),
             'brand_color' => '#F5A623',

--- a/app/Modules/PaymentMethods/PromoGateways/Addons/MercadoPagoAddon.php
+++ b/app/Modules/PaymentMethods/PromoGateways/Addons/MercadoPagoAddon.php
@@ -41,7 +41,7 @@ class MercadoPagoAddon extends AbstractPaymentGateway
             'title' => 'Mercado Pago',
             'route' => 'mercado_pago',
             'slug' => 'mercado_pago',
-            'description' => 'Pay securely with Mercado Pago - Cards, Pix, Boleto, OXXO, and more',
+            'description' => __('Pay securely with Mercado Pago - Cards, Pix, Boleto, OXXO, and more', 'fluent-cart'),
             'logo' => Vite::getAssetUrl("images/payment-methods/mercado-pago-logo.svg"),
             'icon' => Vite::getAssetUrl("images/payment-methods/mercado-pago-logo.svg"),
             'brand_color' => '#009EE3',

--- a/app/Modules/PaymentMethods/PromoGateways/Addons/PaystackAddon.php
+++ b/app/Modules/PaymentMethods/PromoGateways/Addons/PaystackAddon.php
@@ -41,7 +41,7 @@ class PaystackAddon extends AbstractPaymentGateway
             'title' => 'Paystack',
             'route' => 'paystack',
             'slug' => 'paystack',
-            'description' => 'Pay securely with Paystack - Cards, Bank Transfer, USSD, and Mobile Money',
+            'description' => __('Pay securely with Paystack - Cards, Bank Transfer, USSD, and Mobile Money', 'fluent-cart'),
             'logo' => Vite::getAssetUrl("images/payment-methods/paystack-logo.svg"),
             'icon' => Vite::getAssetUrl("images/payment-methods/paystack-logo.svg"),
             'brand_color' => '#0fa958',

--- a/app/Modules/PaymentMethods/PromoGateways/Addons/RazorpayAddon.php
+++ b/app/Modules/PaymentMethods/PromoGateways/Addons/RazorpayAddon.php
@@ -41,7 +41,7 @@ class RazorpayAddon extends AbstractPaymentGateway
             'title' => 'Razorpay',
             'route' => 'razorpay',
             'slug' => 'razorpay',
-            'description' => 'Pay securely with Razorpay - UPI, Cards, NetBanking, and Wallets',
+            'description' => __('Pay securely with Razorpay - UPI, Cards, NetBanking, and Wallets', 'fluent-cart'),
             'logo' => Vite::getAssetUrl("images/payment-methods/razorpay-logo.svg"),
             'icon' => Vite::getAssetUrl("images/payment-methods/razorpay-logo.svg"),
             'brand_color' => '#0fa958',

--- a/app/Modules/PaymentMethods/PromoGateways/Pro/AuthorizeNetPromo.php
+++ b/app/Modules/PaymentMethods/PromoGateways/Pro/AuthorizeNetPromo.php
@@ -28,7 +28,7 @@ class AuthorizeNetPromo extends AbstractPaymentGateway
             'title' => 'Authorize.Net',
             'route' => 'authorize_dot_net',
             'slug' => 'authorize_dot_net',
-            'description' => 'Pay securely with Authorize.Net - Credit and Debit Cards',
+            'description' => __('Pay securely with Authorize.Net - Credit and Debit Cards', 'fluent-cart'),
             'logo' => Vite::getAssetUrl("images/payment-methods/authorize_dot_net-logo.svg"),
             'icon' => Vite::getAssetUrl("images/payment-methods/authorize_dot_net-logo.svg"),
             'brand_color' => '#0066cc',

--- a/app/Modules/PaymentMethods/PromoGateways/Pro/MolliePromo.php
+++ b/app/Modules/PaymentMethods/PromoGateways/Pro/MolliePromo.php
@@ -22,7 +22,7 @@ class MolliePromo extends AbstractPaymentGateway
             'title' => 'Mollie',
             'route' => 'mollie',
             'slug' => 'mollie',
-            'description' => 'Pay securely with Mollie - Credit Card, PayPal, SEPA, and more.',
+            'description' => __('Pay securely with Mollie - Credit Card, PayPal, SEPA, and more.', 'fluent-cart'),
             'logo' => Vite::getAssetUrl("images/payment-methods/mollie-logo.svg"),
             'icon' => Vite::getAssetUrl("images/payment-methods/mollie-icon.svg"),
             'brand_color' => '#7c3aed',

--- a/app/Modules/PaymentMethods/PromoGateways/Pro/PaddlePromo.php
+++ b/app/Modules/PaymentMethods/PromoGateways/Pro/PaddlePromo.php
@@ -22,7 +22,7 @@ class PaddlePromo extends AbstractPaymentGateway
             'title' => 'Paddle',
             'route' => 'paddle',
             'slug' => 'paddle',
-            'description' => 'Accept credit cards and PayPal payments securely with Paddle. Available in FluentCart Pro.',
+            'description' => __('Accept credit cards and PayPal payments securely with Paddle. Available in FluentCart Pro.', 'fluent-cart'),
             'logo' => Vite::getAssetUrl("images/payment-methods/paddle-logo.svg"),
             'icon' => Vite::getAssetUrl("images/payment-methods/paddle-logo.svg"),
             'brand_color' => '#7c3aed',

--- a/app/Modules/PaymentMethods/StripeGateway/Stripe.php
+++ b/app/Modules/PaymentMethods/StripeGateway/Stripe.php
@@ -56,7 +56,7 @@ class Stripe extends AbstractPaymentGateway
     public function meta(): array
     {
         return [
-            'title'              => 'Card',
+            'title'              => __('Card', 'fluent-cart'),
             'route'              => 'stripe',
             'slug'               => 'stripe',
             'label'              => 'Stripe',


### PR DESCRIPTION
## Summary
- Reopens the i18n fix from the previously auto-closed PR by applying it on top of the latest `master`
- Wraps Stripe gateway `title` ("Card") and promo/addon gateway `description` strings with `__()` for translation support
- Intentionally keeps brand names (Stripe, PayPal, etc.) unwrapped

## Test Plan
- Verify Stripe payment method still displays "Card" at checkout
- Verify promo gateway descriptions render in admin
- Switch to a non-English locale and confirm strings are picked up for translation

Made with [Cursor](https://cursor.com)